### PR TITLE
Add chromem-go to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [milvus](https://milvus.io/)
 - [infinity](https://github.com/infiniflow/infinity)
 - [havenask](https://github.com/alibaba/havenask)
+- [chromem-go](https://github.com/philippgille/chromem-go)
 
 ## Texts
 


### PR DESCRIPTION
Hi :wave: , thanks for creating and maintaining this overview! I've been working on [chromem-go](https://github.com/philippgille/chromem-go), which differs from most other vector databases in that it's embeddable in Go (no client-server model, no CGO). I'd be very happy if it can be added to this awesome list!