### PR TITLE
Add Rivestack to Services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [SuperDuperDB](https://github.com/SuperDuperDB/superduperdb)
 - [KBD.AI](https://kdb.ai/)
 - [Denser Retriever](https://denser.ai)
+- [Rivestack](https://rivestack.io) — Managed PostgreSQL with pgvector for AI workloads. HNSW indexing, built-in SQL editor with embedding search, free tier available.
 
 ## Comparisons
 - [From Vespa](https://cloud.vespa.ai/feature-comparison.html)


### PR DESCRIPTION
Rivestack is a managed PostgreSQL service with built-in pgvector for AI vector search workloads. Offers HNSW indexing, a SQL editor that converts search queries to embeddings, NVMe storage, and a free tier.