### PR TITLE
Add Omnigraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [havenask](https://github.com/alibaba/havenask)
 - [chromem-go](https://github.com/philippgille/chromem-go)
 - [OasysDB](https://github.com/oasysai/oasysdb) [[Notebook](https://colab.research.google.com/drive/15_1hH7jGKzMeQ6IfnScjsc-iJRL5XyL7?usp=sharing)]
-- [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database with vector + BM25 hybrid search in one Rust runtime. S3-native, Git-style branch/merge.
+- [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database for agent memory. S3-native, Rust, vector + BM25 in one runtime, Git-style branch/merge.
 - [Meilisearch](https://github.com/meilisearch) - Search engine API for Semantic (vectors), full-text & hybrid search
 - [arroy](https://github.com/meilisearch/arroy) - Approximate Nearest Neighbors Rust library
 - [bleve](https://github.com/blevesearch/bleve)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [havenask](https://github.com/alibaba/havenask)
 - [chromem-go](https://github.com/philippgille/chromem-go)
 - [OasysDB](https://github.com/oasysai/oasysdb) [[Notebook](https://colab.research.google.com/drive/15_1hH7jGKzMeQ6IfnScjsc-iJRL5XyL7?usp=sharing)]
+- [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database with vector + BM25 hybrid search, S3-native storage, and Git-style branch/merge. Rust.
 - [Meilisearch](https://github.com/meilisearch) - Search engine API for Semantic (vectors), full-text & hybrid search
 - [arroy](https://github.com/meilisearch/arroy) - Approximate Nearest Neighbors Rust library
 - [bleve](https://github.com/blevesearch/bleve)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [havenask](https://github.com/alibaba/havenask)
 - [chromem-go](https://github.com/philippgille/chromem-go)
 - [OasysDB](https://github.com/oasysai/oasysdb) [[Notebook](https://colab.research.google.com/drive/15_1hH7jGKzMeQ6IfnScjsc-iJRL5XyL7?usp=sharing)]
-- [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database with vector + BM25 hybrid search, S3-native storage, and Git-style branch/merge. Rust.
+- [Omnigraph](https://github.com/ModernRelay/omnigraph) - Typed graph database with vector + BM25 hybrid search in one Rust runtime. S3-native, Git-style branch/merge.
 - [Meilisearch](https://github.com/meilisearch) - Search engine API for Semantic (vectors), full-text & hybrid search
 - [arroy](https://github.com/meilisearch/arroy) - Approximate Nearest Neighbors Rust library
 - [bleve](https://github.com/blevesearch/bleve)


### PR DESCRIPTION
Omnigraph is an open-source graph database with built-in vector and BM25
search in a single Rust runtime. Also supports typed schemas, S3-native
storage, and Git-style branch/merge for agent memory workflows.

https://github.com/ModernRelay/omnigraph