### PR TITLE
Add Dakera: self-hosted agent memory with HNSW vector indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [seekdb](https://github.com/oceanbase/seekdb)
 - [brinicle](https://github.com/bicardinal/brinicle) - Resource-efficient C++ vector index engine built for low-RAM production workloads
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) - Embedded vector + graph + columnar database. Rust core (~6MB), HNSW with 5 distance metrics, VelesQL (SQL + NEAR + MATCH). Python and Rust SDKs.
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with HNSW vector indexing and RocksDB persistence. Decay-weighted recall, multi-session support, and cross-agent knowledge sharing. MCP-native with Python, JavaScript, Rust, and Go SDKs.
 
 ## Texts
 


### PR DESCRIPTION
## Description

Adding **[Dakera](https://github.com/dakera-ai/dakera-mcp)** to the Libraries & Engines section.

Dakera is a self-hosted agent memory server that uses HNSW vector indexing with RocksDB persistence for durable, high-performance retrieval. It is particularly relevant to this list because:

- **HNSW-based vector search** for approximate nearest neighbor retrieval over agent memories
- **RocksDB persistence** for durable storage with fast reads
- **Decay-weighted recall** — memories are scored by recency and importance, not just vector similarity
- **MCP-native** (Model Context Protocol) — purpose-built for AI agent memory workflows
- **Multi-session and cross-agent** knowledge sharing
- SDKs available: Python, JavaScript, Rust, and Go

**Links:**
- Server: https://github.com/dakera-ai/dakera-mcp
- Deploy (self-hosted): https://github.com/dakera-ai/dakera-deploy
- Docs: https://github.com/dakera-ai/dakera-docs