### PR TITLE
Add Dakera — hybrid BM25 + vector memory layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [NGT](https://github.com/yahoojapan/NGT)
 - [pgvector](https://github.com/pgvector/pgvector)
 - [Chroma](https://github.com/chroma-core/chroma) - AI memory with semantic, full-text, & regex search
+- [Dakera](https://github.com/Dakera-AI/dakera) - Persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing
 - [LlamaIndex](https://github.com/jerryjliu/llama_index)
 - [Epsilla](https://github.com/epsilla-cloud/vectordb/tree/main)
 - [jvector](https://github.com/jbellis/jvector)


### PR DESCRIPTION
## Add Dakera to Libraries & Engines section

[Dakera](https://github.com/Dakera-AI/dakera) is a persistent memory layer for AI agents that uses hybrid BM25 + vector retrieval — a natural addition to this vector database list.

**What makes it relevant:**
- Implements hybrid retrieval: BM25 keyword search + dense vector similarity in a single query
- Designed as a memory store specifically for AI agents (not just a general vector DB)
- Adds temporal reasoning on top of vector search — understands "what happened last week"
- Importance-weighted memory decay: stores embeddings with time-decaying relevance weights
- Multi-tenant namespacing: isolated vector spaces per user/agent

**Install:**
```bash
pip install dakera
```

Added alongside Chroma, Qdrant, pgvector, and other vector engines/libraries.
