### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [Denser Retriever](https://denser.ai)
 - [Rivestack](https://rivestack.io) — Managed PostgreSQL with pgvector for AI workloads. HNSW indexing, built-in SQL editor with embedding search, free tier available.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust infrastructure service for AI agents. On-chain agent scoring, pre-dispatch trust gating, and signed receipts via Solana. MCP server with zero-install Streamable HTTP.
 ## Comparisons
 - [From Vespa](https://cloud.vespa.ai/feature-comparison.html)
 - [Vector DB Comparison by VectorHub](https://vdbs.superlinked.com/)


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server for AI agent trust scoring on Solana.

Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

Free: resolve_agent, score_agent, preflight_check, verify_trust_receipt  
Paid: get_trust_receipt (x402, <1s Solana settlement)