### PR TITLE
feat: add TWZRD Agent Intel to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [Denser Retriever](https://denser.ai)
 - [Rivestack](https://rivestack.io) — Managed PostgreSQL with pgvector for AI workloads. HNSW indexing, built-in SQL editor with embedding search, free tier available.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust infrastructure service for AI agents. On-chain agent scoring, pre-dispatch trust gating, and signed receipts via Solana. MCP server with zero-install Streamable HTTP.
 ## Comparisons
 - [From Vespa](https://cloud.vespa.ai/feature-comparison.html)
 - [Vector DB Comparison by VectorHub](https://vdbs.superlinked.com/)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [KBD.AI](https://kdb.ai/)
 - [Denser Retriever](https://denser.ai)
 - [Rivestack](https://rivestack.io) — Managed PostgreSQL with pgvector for AI workloads. HNSW indexing, built-in SQL editor with embedding search, free tier available.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — Agent wallet trust scoring for RAG pipelines. Verify agent identity before paid vector retrieval or premium embedding API access via x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 - [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust infrastructure service for AI agents. On-chain agent scoring, pre-dispatch trust gating, and signed receipts via Solana. MCP server with zero-install Streamable HTTP.
 ## Comparisons


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Services section.

TWZRD Agent Intel provides agent wallet trust scoring for RAG pipelines — verify AI agent identity before granting access to paid vector retrieval or premium embedding APIs. Useful when building multi-agent RAG systems that need to gate access to vector database queries based on agent identity.

- **Free MCP**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
- **Tools**: `score_agent(wallet)`, `preflight_check(wallet)` — free; `get_trust_receipt(wallet)` — paid via x402 micropayment
- **Use case**: trust layer for RAG agents — verify agent identity before paid document retrieval or premium embedding API access