### PR TITLE
feat: Add null-drift as an O(1) VectorDB alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [seekdb](https://github.com/oceanbase/seekdb)
 - [brinicle](https://github.com/bicardinal/brinicle) - Resource-efficient C++ vector index engine built for low-RAM production workloads
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) - Embedded vector + graph + columnar database. Rust core (~6MB), HNSW with 5 distance metrics, VelesQL (SQL + NEAR + MATCH). Python and Rust SDKs.
+- [null-drift](https://github.com/CodNoob100/null-drift) - Bare-metal O(1) continuous state memory daemon designed as a lock-free VectorDB replacement.
 
 ## Texts
 


### PR DESCRIPTION
Hi maintainers! I'd like to propose adding null-drift to the Multidimensional data / Vectors section. It serves as a highly performant alternative to traditional VectorDBs for continuous AI agents. Written entirely in bare-metal Rust, it completely eliminates the concept of context bloat by projecting semantic embeddings into a bipolar phase space using a geometric decay array. This allows local AI agents to run in perpetuity with an immovable O(1) memory ceiling. I believe it would be a highly unique and valuable infrastructure addition to this list!