### PR TITLE
Add infino

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [seekdb](https://github.com/oceanbase/seekdb)
 - [brinicle](https://github.com/bicardinal/brinicle) - Resource-efficient C++ vector index engine built for low-RAM production workloads
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) - Embedded vector + graph + columnar database. Rust core (~6MB), HNSW with 5 distance metrics, VelesQL (SQL + NEAR + MATCH). Python and Rust SDKs.
+- [infino](https://github.com/infino-ai/infino) - Embedded retrieval engine with SQL, full-text (BM25), and vector search over a single copy of your data as Parquet on object storage. Rust core, Apache-2.0.
 
 ## Texts
 


### PR DESCRIPTION
Adds [infino](https://github.com/infino-ai/infino) — an embedded retrieval engine running SQL, full-text (BM25), and vector search over one copy of your data as Parquet on object storage (S3/Azure/local). Rust core with Python/Node bindings, Apache-2.0, available on crates.io/PyPI/npm. Appended to the *Multidimensional data / Vectors* section.