### PR TITLE
Add Samyama Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [brinicle](https://github.com/bicardinal/brinicle) - Resource-efficient C++ vector index engine built for low-RAM production workloads
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) - Embedded vector + graph + columnar database. Rust core (~6MB), HNSW with 5 distance metrics, VelesQL (SQL + NEAR + MATCH). Python and Rust SDKs.
 - [infino](https://github.com/infino-ai/infino) - Embedded retrieval engine with SQL, full-text (BM25), and vector search over a single copy of your data as Parquet on object storage. Rust core, Apache-2.0.
+- [samyama-graph](https://github.com/samyama-ai/samyama-graph) - Graph and vector database in one Rust engine. Property-graph traversal with ~90% openCypher, HNSW vector search, and auto-generated MCP servers. Apache-2.0.
 
 ## Texts
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A curated list of awesome works related to high dimensional structure/vector sea
 - [brinicle](https://github.com/bicardinal/brinicle) - Resource-efficient C++ vector index engine built for low-RAM production workloads
 - [VelesDB](https://github.com/cyberlife-coder/VelesDB) - Embedded vector + graph + columnar database. Rust core (~6MB), HNSW with 5 distance metrics, VelesQL (SQL + NEAR + MATCH). Python and Rust SDKs.
 - [infino](https://github.com/infino-ai/infino) - Embedded retrieval engine with SQL, full-text (BM25), and vector search over a single copy of your data as Parquet on object storage. Rust core, Apache-2.0.
-- [samyama-graph](https://github.com/samyama-ai/samyama-graph) - Graph and vector database in one Rust engine. Property-graph traversal with ~90% openCypher, HNSW vector search, and auto-generated MCP servers. Apache-2.0.
+- [samyama-graph](https://github.com/samyama-ai/samyama-graph) - Graph and vector database in one Rust engine. Property-graph traversal with openCypher, HNSW vector search, and auto-generated MCP servers. Apache-2.0.
 
 ## Texts
 


### PR DESCRIPTION
Adds [samyama-ai/samyama-graph](https://github.com/samyama-ai/samyama-graph), an Apache-2.0 graph-vector database written in Rust: property-graph traversal with ~90% openCypher coverage and HNSW vector search in a single engine.

- Repo: https://github.com/samyama-ai/samyama-graph — 78 stars, actively developed, v1.7.0 released 2026-07-21
- License: Apache-2.0
- Docs: https://graph.samyama.cloud/book/
- openCypher coverage is deliberately described as *~90%*; the known gaps are documented in [docs/CYPHER_COMPATIBILITY.md](https://github.com/samyama-ai/samyama-graph/blob/main/docs/CYPHER_COMPATIBILITY.md).

Entry placed in **Libraries & Engines > Multidimensional data / Vectors**, following the surrounding formatting. Disclosure: I work with the team behind this project. Happy to adjust the wording or placement.
